### PR TITLE
Fix: Update to resource not reflected until operator restart

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"

--- a/kaspr/app.py
+++ b/kaspr/app.py
@@ -8,7 +8,7 @@ import kaspr.handlers.kasprwebview as kasprwebview
 @kopf.on.startup()
 def configure_settings(settings: kopf.OperatorSettings, **kwargs):
     # Limit the number of concurrent workers to prevent flooding the API
-    settings.batching.worker_limit = 1
+    settings.batching.worker_limit = 2
     
     # Disable posting events to the Kubernetes API for logging > Warning
     settings.posting.enabled = True

--- a/kaspr/handlers/kasprwebview.py
+++ b/kaspr/handlers/kasprwebview.py
@@ -30,7 +30,7 @@ kopf_logger.addFilter(TimerLogFilter())
 @kopf.on.resume(kind=KIND)
 @kopf.on.create(kind=KIND)
 @kopf.on.update(kind=KIND)
-def reconciliation(
+async def reconciliation(
     body, spec, name, namespace, logger, labels, patch, annotations, **kwargs
 ):
     """Reconcile KasprWebView resources."""
@@ -47,7 +47,6 @@ def reconciliation(
             },
             "configMap": webview.config_map_name,
             "hash": webview.hash,
-            "lastUpdateTime": utc_now().isoformat(),
         }
     )
     if app is None:
@@ -89,11 +88,21 @@ async def patch_resource(name, patch, **kwargs):
     kind=KIND, cancellation_backoff=2.0, cancellation_timeout=5.0, initial_delay=5.0
 )
 async def monitor_webview(
-    stopped, name, body, spec, meta, labels, status, namespace, patch, logger, **kwargs
+    stopped,
+    name,
+    body,
+    spec,
+    meta,
+    labels,
+    status,
+    namespace,
+    patch,
+    logger: logging.Logger,
+    **kwargs,
 ):
     """Monitor webview resources for status updates."""
-    try:
-        while not stopped:
+    while not stopped:
+        try:
             _status = benedict(status, keyattr_dynamic=True)
             _status_updates = benedict(keyattr_dynamic=True)
             spec_model: KasprWebViewSpec = KasprWebViewSpecSchema().load(spec)
@@ -122,18 +131,19 @@ async def monitor_webview(
                 await patch_request_queues[name].put(
                     [
                         {"field": "status", "value": _status_updates},
-                        {
-                            "field": "status",
-                            "value": {"lastUpdateTime": utc_now().isoformat()},
-                        },
                     ]
                 )
 
             await asyncio.sleep(10)
-    except asyncio.CancelledError:
-        print("We are done. Bye.")
+        except asyncio.CancelledError:
+            logger.info("Monitoring stopped.")
+            break
+        except Exception as e:
+            logger.error("Unexpected error during monitoring: {e}")
+            logger.exception(e)
 
-@kopf.timer(KIND, initial_delay=5.0, interval=60.0)
+
+@kopf.timer(KIND, initial_delay=5.0, interval=60.0, backoff=10.0)
 async def reconcile(name, spec, namespace, labels, logger: logging.Logger, **kwargs):
     """Full sync."""
     spec_model: KasprWebViewSpec = KasprWebViewSpecSchema().load(spec)
@@ -145,7 +155,6 @@ async def reconcile(name, spec, namespace, labels, logger: logging.Logger, **kwa
     except Exception as e:
         logger.error(f"Unexpected error during reconcilation: {e}")
         logger.exception(e)
-        raise e
 
 
 # @kopf.on.validate(kind=KIND)


### PR DESCRIPTION
* Removes several experimental parts of resource event handlers that manage status fields. Status fields will be revisted to be made more stable and reliable.