### PR TITLE
Default to kaspr v0.6.7

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.6.1",
+            version="0.6.7",
+            image="kasprio/kaspr:0.6.7-alpha",
+            supported=True,
+            default=True,
+        ),            
+        KasprVersion(
             operator_version="0.6.0",
             version="0.6.0",
             image="kasprio/kaspr:0.6.6-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),        
         KasprVersion(
             operator_version="0.5.28",


### PR DESCRIPTION
This pull request updates the Kaspr application to support a new operator version and bumps the package version. The main focus is on adding support for operator version 0.6.1 and setting it as the new default, while the previous default is updated accordingly.

Versioning updates:

* Bumped the package version from `0.6.0` to `0.6.1` in `kaspr/__init__.py`.

Operator version support:

* Added a new `KasprVersion` entry for operator version `0.6.1` (mapping to app version `0.6.7` and image `kasprio/kaspr:0.6.7-alpha`), and set it as the default supported version in `kaspr/types/models/version_resources.py`.
* Updated the previous default (`0.6.0`) to no longer be the default.