### PR TITLE
Support for KasprApp status

### DIFF
--- a/crds/kasprapp.crd.yaml
+++ b/crds/kasprapp.crd.yaml
@@ -959,3 +959,48 @@ spec:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+                kasprVersion:
+                  type: string
+                conditions:
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - type
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - reason
+                      - lastTransitionTime
+                      - observedGeneration
+                    properties:
+                      type:
+                        type: string
+                        minLength: 1
+                      status:
+                        type: string
+                        enum: ["True","False","Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      observedGeneration:
+                        type: integer
+                        format: int64   
+      subresources:
+        status: {}      
+      additionalPrinterColumns:
+      - name: Ready
+        jsonPath: .status.conditions[?(@.type=="Ready")].status
+        type: string
+      - name: Kaspr
+        jsonPath: .status.kasprVersion
+        type: string

--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.6.5"
+__version__ = "0.7.0"

--- a/kaspr/resources/base.py
+++ b/kaspr/resources/base.py
@@ -259,7 +259,12 @@ class BaseResource:
         namespace: str,
         delete_options: V1DeleteOptions,
     ):
-        apps_v1_api.delete_namespaced_stateful_set(name, namespace, body=delete_options)
+        try:
+            apps_v1_api.delete_namespaced_stateful_set(name, namespace, body=delete_options)
+        except ApiException as ex:
+            if ex.status == 404:
+                return
+            raise
 
     def fetch_secret(
         self, core_v1_api: CoreV1Api, name: str, namespace: str

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.6.5",
+            version="0.6.9",
+            image="kasprio/kaspr:0.6.9-alpha",
+            supported=True,
+            default=True,
+        ),          
+        KasprVersion(
             operator_version="0.6.3",
             version="0.6.8",
             image="kasprio/kaspr:0.6.8-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.6.2",

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.7.0",
+            version="0.6.10",
+            image="kasprio/kaspr:0.6.10-alpha",
+            supported=True,
+            default=True,
+        ),            
+        KasprVersion(
             operator_version="0.6.5",
             version="0.6.9",
             image="kasprio/kaspr:0.6.9-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.6.3",

--- a/kaspr/types/schemas/storage.py
+++ b/kaspr/types/schemas/storage.py
@@ -8,7 +8,7 @@ class KasprAppStorageSchema(BaseSchema):
 
     __model__ = KasprAppStorage
 
-    type = fields.Str(data_key="type", default=None)
+    type = fields.Str(data_key="type", required=True)
     storage_class = fields.Str(data_key="class", required=True)
     size = fields.Str(data_key="size", required=True)
-    delete_claim = fields.Bool(data_key="deleteClaim", default=None)
+    delete_claim = fields.Bool(data_key="deleteClaim", load_default=None)


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the Kaspr operator and application, focusing on improved status reporting, versioning, schema validation, and robustness in resource management. The key changes include updates to the CRD for richer status information, new utilities for handling conditions, improvements in version mapping, and better error handling.

**Status and CRD Improvements:**

* Expanded the `kasprapp` CRD status schema to include `observedGeneration`, `kasprVersion`, and a detailed `conditions` array, along with new printer columns for `Ready` and `Kaspr` version. This enables more informative and Kubernetes-native status reporting.
* Added a `fetch_app_status` method to the `KasprApp` resource to report the running Kaspr image version and available replicas, supporting the enhanced status in the CRD.

**Versioning Enhancements:**

* Updated the default operator and Kaspr application version mapping to set `0.7.0` as the new default, and added its associated image and version.
* Bumped the Python package version to `0.7.0` to reflect these changes.

**Schema and Validation Updates:**

* Made the `type` field required in the storage schema and refined the handling of the `delete_claim` field to use `load_default=None` for better Marshmallow compatibility.

**Utilities and Helpers:**

* Added a new `upsert_condition` utility for merging status conditions in-memory, ensuring `lastTransitionTime` is updated only when the status changes. Also introduced a `now()` helper returning ISO-formatted current UTC time. [[1]](diffhunk://#diff-4e74ecf1ab60285914654f482f16f68c20a2c4ca4bb8fe848a20c54bcc37ad30L12-R16) [[2]](diffhunk://#diff-4e74ecf1ab60285914654f482f16f68c20a2c4ca4bb8fe848a20c54bcc37ad30R239-R253)

**Bug Fixes and Robustness:**

* Improved `delete_stateful_set` to gracefully handle `404 Not Found` errors, preventing exceptions when the resource does not exist.
* Fixed environment variable population in `KasprApp` to use public hash properties instead of private attributes, improving maintainability and correctness.