### PR TITLE
Bump version to 0.7.3 and update HPA scaling policy

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/kaspr/resources/kasprapp.py
+++ b/kaspr/resources/kasprapp.py
@@ -1161,12 +1161,12 @@ class KasprApp(BaseResource):
                             V2HPAScalingPolicy(
                                 type="Percent",
                                 value=100,
-                                period_seconds=30,
+                                period_seconds=60,
                             ),
                             V2HPAScalingPolicy(
                                 type="Pods",
                                 value=4,
-                                period_seconds=30,
+                                period_seconds=60,
                             ),
                         ],
                         select_policy="Max",


### PR DESCRIPTION
Incremented the package version to 0.7.3. Updated the HPA scaling policy in KasprApp to use a 60 second period for both Percent and Pods scaling policies, instead of 30 seconds.