### PR TITLE
Bump package to 0.16.0 and add mapping

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.16.0",
+            version="0.8.0",
+            image="kasprio/kaspr:0.8.0-alpha",
+            supported=True,
+            default=True,
+        ),          
+        KasprVersion(
             operator_version="0.14.5",
             version="0.7.5",
             image="kasprio/kaspr:0.7.6-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.14.4",


### PR DESCRIPTION
This pull request updates versioning across the project to introduce support for the new operator and application versions. The main changes include bumping the package version and adding a new supported version mapping, while updating the default version.

**Versioning updates:**

* Bumped the package version in `kaspr/__init__.py` from `0.15.1` to `0.16.0`.

**Operator and application version management:**

* Added a new `KasprVersion` entry for operator version `0.16.0` and application version `0.8.0`, marking it as supported and default in `kaspr/types/models/version_resources.py`.
* Updated the previous default version (`0.14.5`/`0.7.5`) to no longer be the default.