### PR TITLE
Bump to 0.16.1 and add 0.8.1 mapping

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -24,10 +24,17 @@ class KasprVersionResources:
     _VERSIONS = (
         KasprVersion(
             operator_version="0.16.0",
+            version="0.8.1",
+            image="kasprio/kaspr:0.8.1-alpha",
+            supported=True,
+            default=True,
+        ),
+        KasprVersion(
+            operator_version="0.16.0",
             version="0.8.0",
             image="kasprio/kaspr:0.8.0-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.14.5",


### PR DESCRIPTION
This pull request updates the Kaspr versioning to support a new application version and adjusts the default version mapping. The main changes are:

Version management updates:

* Added a new `KasprVersion` entry for application version `0.8.1` (with operator version `0.16.0`) and set it as the default supported version in `KasprVersionResources` (`kaspr/types/models/version_resources.py`).
* Updated the previous default version (`0.8.0` for operator version `0.16.0`) to no longer be the default.

Package version bump:

* Bumped the package version from `0.16.0` to `0.16.1` in `kaspr/__init__.py`.