### PR TITLE
Add support for custom kaspr image registry

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"

--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/kaspr/resources/kasprapp.py
+++ b/kaspr/resources/kasprapp.py
@@ -852,8 +852,12 @@ class KasprApp(BaseResource):
 
     def prepare_image(self) -> str:
         """Container image to use."""
-        # Use image provide in spec, otherwise use the image defined for the given version
-        return self._image if self._image else self.version.image
+        # Use image provided in spec, otherwise use the image defined for the given version
+        image = self._image if self._image else self.version.image
+        # Prepend custom registry if configured
+        if self.conf.kaspr_image_registry:
+            image = f"{self.conf.kaspr_image_registry.rstrip('/')}/{image}"
+        return image
 
     def prepare_service(self) -> V1Service:
         """Build service resource."""

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
-            operator_version="0.17.0",
+            operator_version="0.17.2",
             version="0.9.1",
             image="kasprio/kaspr:0.9.1-alpha",
             supported=True,
             default=True,
+        ),        
+        KasprVersion(
+            operator_version="0.17.0",
+            version="0.9.1",
+            image="kasprio/kaspr:0.9.1-alpha",
+            supported=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.16.0",

--- a/kaspr/types/settings.py
+++ b/kaspr/types/settings.py
@@ -67,8 +67,6 @@ CLIENT_STATUS_CHECK_TIMEOUT_SECONDS = float(
 )
 
 #: Custom container image registry to use instead of Docker Hub
-#: e.g. "sipapexdev.azurecr.io" will turn "kasprio/kaspr:0.9.1-alpha"
-#: into "sipapexdev.azurecr.io/kasprio/kaspr:0.9.1-alpha"
 KASPR_IMAGE_REGISTRY = str(_getenv("KASPR_IMAGE_REGISTRY", ""))
 
 #: Enable automatic rebalance when Kafka subscriptions change

--- a/kaspr/types/settings.py
+++ b/kaspr/types/settings.py
@@ -66,6 +66,11 @@ CLIENT_STATUS_CHECK_TIMEOUT_SECONDS = float(
     _getenv("CLIENT_STATUS_CHECK_TIMEOUT_SECONDS", 15.0)
 )
 
+#: Custom container image registry to use instead of Docker Hub
+#: e.g. "sipapexdev.azurecr.io" will turn "kasprio/kaspr:0.9.1-alpha"
+#: into "sipapexdev.azurecr.io/kasprio/kaspr:0.9.1-alpha"
+KASPR_IMAGE_REGISTRY = str(_getenv("KASPR_IMAGE_REGISTRY", ""))
+
 #: Enable automatic rebalance when Kafka subscriptions change
 AUTO_REBALANCE_ENABLED = bool(
     _getenv("AUTO_REBALANCE_ENABLED", True)
@@ -93,6 +98,7 @@ class Settings:
     auto_rebalance_enabled: bool = AUTO_REBALANCE_ENABLED
     hung_member_detection_enabled: bool = HUNG_MEMBER_DETECTION_ENABLED
     hung_rebalancing_threshold_seconds: int = HUNG_REBALANCING_THRESHOLD_SECONDS
+    kaspr_image_registry: str = KASPR_IMAGE_REGISTRY
 
     def __init__(
         self,


### PR DESCRIPTION
This pull request introduces support for configuring a custom container image registry for Kaspr deployments, updates version mappings, and bumps the package version. The main changes focus on making the image registry configurable via settings, ensuring images are pulled from the correct location, and updating supported operator versions.

**Image registry configuration:**

* Added the `KASPR_IMAGE_REGISTRY` environment variable and corresponding `kaspr_image_registry` setting to allow specifying a custom container image registry instead of Docker Hub. (`kaspr/types/settings.py`) [[1]](diffhunk://#diff-fe6cabf2eb2eced1deeee34a1ed3264afe27b85d32e4de9a6605eafcd81e2478R69-R71) [[2]](diffhunk://#diff-fe6cabf2eb2eced1deeee34a1ed3264afe27b85d32e4de9a6605eafcd81e2478R99)
* Updated the image selection logic in `prepare_image` to prepend the custom registry if configured, ensuring container images are pulled from the specified registry. (`kaspr/resources/kasprapp.py`)

**Version management:**

* Updated the `_VERSIONS` tuple to set `operator_version="0.17.2"` as the new default and added an explicit entry for `operator_version="0.17.0"` with `default=False`. (`kaspr/types/models/version_resources.py`)

**Miscellaneous:**

* Bumped the package version from `0.17.1` to `0.17.3` to reflect these changes. (`kaspr/__init__.py`)